### PR TITLE
Support for edited dvr recordings

### DIFF
--- a/src/osd-overlay/mp4/parsers.ts
+++ b/src/osd-overlay/mp4/parsers.ts
@@ -34,6 +34,7 @@ import {
   UrlBox,
   UrnBox,
   VmhdBox,
+  CttsBox,
 } from "./types";
 
 export async function parseBox(stream: FileStreamReader): Promise<Box> {
@@ -88,6 +89,7 @@ export async function parseBox(stream: FileStreamReader): Promise<Box> {
     trak: TrakBoxParser,
     udta: UdtaBoxParser,
     vmhd: VmhdBoxParser,
+    ctts: CttsBoxParser,
   };
 
   let parser: BoxParser<Box>;
@@ -457,6 +459,7 @@ class StblBoxParser extends SimpleBoxParser<StblBox> {
       stss: childBoxes.stss![0] as StssBox,
       stsz: childBoxes.stsz![0] as StszBox,
       stts: childBoxes.stts![0] as SttsBox,
+      ctts: childBoxes.ctts![0] as CttsBox
     };
   }
 }
@@ -554,7 +557,7 @@ class AvcCBoxParser extends SimpleBoxParser<AvcCBox> {
       const ppsData = await this.stream.getNextBytes(ppsLength);
       pps.push(ppsData);
     }
-
+    
     return {
       header,
       type: "avcC",
@@ -742,8 +745,8 @@ class HdrlBoxParser extends FullBoxParser<HdlrBox> {
 
 class VmhdBoxParser extends FullBoxParser<VmhdBox> {
   async parseBox(
-    header: BoxHeader,
-    fullBoxHeader: FullBoxHeader
+      header: BoxHeader,
+      fullBoxHeader: FullBoxHeader
   ): Promise<VmhdBox> {
     const graphicsMode = await this.stream.getNextUint16();
     const opColor = [
@@ -758,6 +761,30 @@ class VmhdBoxParser extends FullBoxParser<VmhdBox> {
       type: "vmhd",
       graphicsMode,
       opColor,
+    };
+  }
+}
+
+class CttsBoxParser extends FullBoxParser<CttsBox> {
+  async parseBox(
+      header: BoxHeader,
+      fullBoxHeader: FullBoxHeader
+  ): Promise<CttsBox> {
+    const sampleCount = await this.stream.getNextUint32();
+    let sampleCounts = [];
+    let sampleOffsets = [];
+
+    for (let i = 0; i < sampleCount; i++) {
+      sampleCounts.push(await this.stream.getNextUint32());
+      sampleOffsets.push(await this.stream.getNextUint32());
+    }
+
+    return {
+      header,
+      fullBoxHeader,
+      type: "ctts",
+      sampleCounts,
+      sampleOffsets,
     };
   }
 }

--- a/src/osd-overlay/mp4/parsers.ts
+++ b/src/osd-overlay/mp4/parsers.ts
@@ -459,7 +459,7 @@ class StblBoxParser extends SimpleBoxParser<StblBox> {
       stss: childBoxes.stss![0] as StssBox,
       stsz: childBoxes.stsz![0] as StszBox,
       stts: childBoxes.stts![0] as SttsBox,
-      ctts: childBoxes.ctts![0] as CttsBox
+      ctts: childBoxes.ctts ? childBoxes.ctts![0] as CttsBox : undefined
     };
   }
 }

--- a/src/osd-overlay/mp4/types.ts
+++ b/src/osd-overlay/mp4/types.ts
@@ -33,6 +33,7 @@ export type BoxType =
   | "url "
   | "urn "
   | "vmhd"
+  | "ctts"
   | UnknownBoxType;
 
 export type ContainerBox =
@@ -68,6 +69,7 @@ export type Box =
   | UrlBox
   | UrnBox
   | VmhdBox
+  | CttsBox
   | UnknownBox;
 
 export interface BoxHeader {
@@ -124,6 +126,7 @@ export interface StblBox extends BaseBox<"stbl"> {
   stss: StssBox;
   stsz: StszBox;
   stts: SttsBox;
+  ctts?: CttsBox;
 }
 
 export interface UdtaBox extends BaseBox<"udta"> {}
@@ -261,6 +264,11 @@ export interface HdlrBox extends BaseFullBox<"hdlr"> {
 export interface VmhdBox extends BaseFullBox<"vmhd"> {
   graphicsMode: number;
   opColor: number[];
+}
+
+export interface CttsBox extends BaseFullBox<"ctts"> {
+  sampleCounts: number[];
+  sampleOffsets: number[];
 }
 
 export interface UrlBox extends BaseFullBox<"url "> {

--- a/src/osd-overlay/processor.ts
+++ b/src/osd-overlay/processor.ts
@@ -172,7 +172,7 @@ export class Processor {
 
       this.outMp4?.setFramerate(60);
 
-      this.expectedFrames = this.inMp4!.moov!.trak[0].mdia.mdhd.duration;
+      this.expectedFrames = this.inMp4!.moov!.trak[0].mdia.minf.stbl.stsz.sampleCount;
       this.decodedFrames = {};
 
       this.progressInit({
@@ -257,16 +257,19 @@ export class Processor {
         });
 
         this.decoder!.decode(encodedChunk);
-        lastSampleIndex = chunk.index + 1;
         this.queuedForDecode++;
       }
 
       // Wait for all samples to be decoded.
       await this.decoder!.flush();
 
+      // DJI recordings straight from the goggles have all frames in sequence.
+      // Edited files may need reordering of the frames described in the ctts box.
+      const orderedFrames = this.reorderFrames(lastSampleIndex);
+
       // Modify and enque frames for encoding.
       this.encodedFrames = [];
-      for (const [index, entry] of Object.values(this.decodedFrames).entries()) {
+      for (const entry of orderedFrames) {
         if (!entry.image) {
           console.error(`Frame ${entry.index} was never decoded!`);
           this.framesDecodedMissing++;
@@ -278,14 +281,12 @@ export class Processor {
           duration: 16670,
           timestamp: entry.index,
         });
-
+        
         // Send first frame as preview. This needs to happen after constructing the frame otherwise
         // it complains that "the image source is detached" which is completely ungooglable.
-        if (index === 0) {
-          this.progressUpdate({
-            preview: modifiedFrame
-          })
-        }
+        this.progressUpdate({
+          preview: modifiedFrame
+        })
 
         this.encoder!.encode(frame, { keyFrame: entry.sync });
         this.queuedForEncode++;
@@ -299,11 +300,45 @@ export class Processor {
       for (const frame of this.encodedFrames) {
         this.outMp4!.writeSample(frame.data, frame.sync);
       }
+
+      lastSampleIndex += sampleChunks.length
     }
 
     await this.outMp4!.close();
     this.sendProgressUpdate();
     this.processResolve!();
+  }
+
+  private reorderFrames(lastSampleIndex: number) {
+    const orderedFrames = []
+    const ctts = this.inMp4!.moov!.trak[0].mdia.minf.stbl.ctts;
+
+    if (!ctts) {
+      // No ctts box found: no reordering needed
+      for (let i = 0; i < Object.keys(this.decodedFrames).length; i++) {
+        orderedFrames.push(this.decodedFrames[lastSampleIndex + i])
+      }
+    } else {
+      // Reorder frames according to ctts table
+      const sampleDelta = this.inMp4!.moov!.trak[0].mdia.minf.stbl.stts.entries[0].sampleDelta;
+      const initialOffset = ctts.sampleOffsets[0] / sampleDelta
+
+      for (let i = 0; i < Object.keys(this.decodedFrames).length; i++) {
+        const frameNumber = lastSampleIndex + i
+
+        let j = 0;
+        let frame = 0;
+        while (frameNumber >= frame) {
+          j++
+          frame = ctts.sampleCounts.slice(0, j).reduce((acc, e) => acc + e, 0)
+        }
+
+        let newPosition = i + ctts.sampleOffsets[j - 1] / sampleDelta - initialOffset;
+        orderedFrames[newPosition] = Object.assign({}, this.decodedFrames[lastSampleIndex + i], {index: lastSampleIndex + newPosition})
+      }
+    }
+
+    return orderedFrames;
   }
 
   private async handleDecodedFrame(frame: VideoFrame) {


### PR DESCRIPTION
Using tools like [superviou](https://github.com/meekaah/SuperViou) and Gyroflow should still allow for the osd to be overlaid, because they don't change the video length.

They do however come with changes to the decoding/presentation order of the frames. This PR adds support for that.